### PR TITLE
No bedrock support command

### DIFF
--- a/src/main/java/com/fancyinnovations/fancyfriend/FancyFriend.java
+++ b/src/main/java/com/fancyinnovations/fancyfriend/FancyFriend.java
@@ -81,6 +81,7 @@ public class FancyFriend {
 
         jda.getGuildById(GUILD_ID).updateCommands().addCommands(
                 Commands.slash("logs", "Use pastes.dev for logs"),
+                Commands.slash("bedrock", "Bedrock Edition support information"),
                 Commands.slash("blankline", "How to add a blank line in a hologram"),
                 Commands.slash("clickable", "Clickable FancyHolograms tutorial"),
                 Commands.slash("converters", "FH & FN converter messages"),

--- a/src/main/java/com/fancyinnovations/fancyfriend/events/Events.java
+++ b/src/main/java/com/fancyinnovations/fancyfriend/events/Events.java
@@ -37,6 +37,8 @@ public class Events extends ListenerAdapter {
             case "logs" -> event.getHook().editOriginal("Please use **[pastes.dev](<https://pastes.dev/>)**, **[mclo.gs](<https://mclo.gs/>)** or a similar service to upload your server logs.")
                 .queue();
 
+            case "bedrock" -> event.getHook().editOriginal("Bedrock Edition is **not** supported and never will be. Our plugins are designed exclusively for Java Edition servers.").queue();
+
             case "blankline" -> event.getHook().editOriginal(
                     "To add a blank line in a hologram, use `<r>` on a new line.").queue();
 


### PR DESCRIPTION
`/bedrock` -> Bedrock Edition is **not** supported and never will be. Our plugins are designed exclusively for Java Edition servers.